### PR TITLE
Request updater fix

### DIFF
--- a/workshop-manager/bin/RequestHandler/client_updater.py
+++ b/workshop-manager/bin/RequestHandler/client_updater.py
@@ -8,6 +8,35 @@ from socketio.namespace import BaseNamespace
 from DataAggregation.webdata_aggregator import getAvailableWorkshops
 
 
+def broadcast_msg(server, ns_name, event, *args):
+    pkt = dict(type="event",
+               name=event,
+               args=args,
+               endpoint=ns_name)
+
+    for sessid, socket in server.sockets.iteritems():
+        socket.send_packet(pkt)
+
+
+def workshops_monitor(server):
+    sizes = []
+    workshops = getAvailableWorkshops()
+    for w in workshops:
+        tmp = [w.workshopName, w.q.qsize()]
+        sizes.append(tmp)
+        broadcast_msg(server, '', 'sizes', tmp)
+
+    while True:
+        curr_workshops = getAvailableWorkshops()
+        for w in curr_workshops:
+            wq = filter(lambda x: x[0] == w.workshopName, sizes)[0]
+            if wq[1] != w.q.qsize():
+                wq[1] = w.q.qsize()
+                logging.info("client_updater: New update being pushed to clients: " + str(wq))
+                broadcast_msg(server, '', 'sizes', wq)
+        time.sleep(1)
+
+
 class RequestHandlerApp(object):
     def __call__(self, environ, start_response):
         if environ['PATH_INFO'].startswith('/socket.io'):
@@ -15,21 +44,10 @@ class RequestHandlerApp(object):
 
 
 class QueueStatusHandler(BaseNamespace, BroadcastMixin):
-    def on_run(self):
-        workshops = getAvailableWorkshops()
+    def on_connect(self):
         sizes = []
+        workshops = getAvailableWorkshops()
         for w in workshops:
             tmp = [w.workshopName, w.q.qsize()]
             sizes.append(tmp)
             self.emit('sizes', tmp)
-
-        while True:
-            curr_workshops = getAvailableWorkshops()
-            for w in curr_workshops:
-                wq = filter(lambda x: x[0] == w.workshopName, sizes)[0]
-
-                if wq[1] != w.q.qsize():
-                    wq[1] = w.q.qsize()
-                    logging.info("client_updater: New update being pushed to clients: " + str(wq))
-                    self.emit('sizes', wq)
-            time.sleep(1)

--- a/workshop-manager/bin/WebServer/templates/index.html
+++ b/workshop-manager/bin/WebServer/templates/index.html
@@ -56,7 +56,7 @@
 
             var socket = io.connect("http://" + window.location.hostname + ":" + {{ socket_io_port }});
             socket.on('connect', function() {
-                socket.emit('run');
+                socket.emit('connect');
             });
 
             socket.on('sizes', function(sizes) {


### PR DESCRIPTION
Found an issue where every client connection was actually spawning its own internal monitoring process for workshop information. This is now fixed and there is only one running process that does the monitoring and pushing out of updates to clients. 